### PR TITLE
fix two typos in \texttt{}

### DIFF
--- a/appendix/stata-guide.tex
+++ b/appendix/stata-guide.tex
@@ -262,7 +262,7 @@ When your line of code is wider than text on a regular paper you should introduc
 A common line breaking length is around 80 characters, and Stata and other code editors
 provide a visible ``guide line'' to tell you when you should start a new line using \texttt{///}.
 This breaks the line in the code editor while telling Stata that the same line of code continues on the next row in the
-code editor. Using the \texttt{#delimit} command is only intended for advanced programming
+code editor. Using the \texttt{\#delimit} command is only intended for advanced programming
 and is discouraged for analytical code in an article in Stata's official journal.\cite{cox2005styleguide}
 These do not need to be horizontally aligned in code unless they have comments,
 since indentations should reflect that the command continues to a new line.

--- a/chapters/planning-data-work.tex
+++ b/chapters/planning-data-work.tex
@@ -303,7 +303,7 @@ or quick document with results as you work on them,
 but not for final papers and reports.
 RMarkdown\sidenote{\url{https://rmarkdown.rstudio.com/}} is the most widely adopted solution in R.
 There are also different options for Markdown in Stata,
-such as German Rodriguez' \textt{markstat},\sidenote{\url{https://data.princeton.edu/stata/markdown}}
+such as German Rodriguez' \texttt{markstat},\sidenote{\url{https://data.princeton.edu/stata/markdown}}
 Stata 15 dynamic documents,\sidenote{\url{https://www.stata.com/new-in-stata/markdown/}}
 and Ben Jann's \texttt{webdoc}\sidenote{\url{http://repec.sowi.unibe.ch/stata/webdoc/index.html}} and
 \texttt{texdoc}.\sidenote{\url{http://repec.sowi.unibe.ch/stata/texdoc/index.html}}


### PR DESCRIPTION
I had to make these two edits for the code to compile in my tex editor