### PR TITLE
Master dofile updates

### DIFF
--- a/code/stata-master-dofile.do
+++ b/code/stata-master-dofile.do
@@ -17,7 +17,8 @@
         ssc install ietoolkit,  replace
     }
 
-    ieboilstart, v(15.1)
+	*Harmonize settings accross users as much as possible
+    ieboilstart, v(13.1)
     `r(version)'
 
 /*******************************************************************************

--- a/code/stata-master-dofile.do
+++ b/code/stata-master-dofile.do
@@ -49,9 +49,10 @@
  REQUIRES:   ${bl_encrypt}/Raw Identified Data/D4DI_baseline_raw_identified.dta
  CREATES:    ${bl_dt}/Raw Deidentified/D4DI_baseline_raw_deidentified.dta
  IDS VAR:    hhid
-------------------------------------------------------------------------------- */
-    do "${bl_do}/Cleaning/deidentify.do"
-
+----------------------------------------------------------------------------- */
+    if (0) { //Change the 0 to 1 to run the baseline de-identification dofile
+        do "${bl_do}/Cleaning/deidentify.do"
+	}
 /*------------------------------------------------------------------------------
     PART 3.2:  Clean baseline data
 --------------------------------------------------------------------------------
@@ -60,8 +61,9 @@
               ${bl_doc}/Codebook baseline.xlsx
   IDS VAR:    hhid
 ----------------------------------------------------------------------------- */
-    do "${bl_do}/Cleaning/cleaning.do"
-
+    if (0) { //Change the 0 to 1 to run the baseline cleaning dofile
+        do "${bl_do}/Cleaning/cleaning.do"
+	}
 /*-----------------------------------------------------------------------------
     PART 3.3:  Construct income indicators
 --------------------------------------------------------------------------------
@@ -70,4 +72,6 @@
               ${bl_dt}/Intermediate/D4DI_baseline_constructed_income.dta
   IDS VAR:    hhid
 ----------------------------------------------------------------------------- */
-    do "${bl_do}/Construct/construct_income.do"
+    if (0) { //Change the 0 to 1 to run the baseline variable construction dofile
+        do "${bl_do}/Construct/construct_income.do"
+	}

--- a/code/stata-master-dofile.do
+++ b/code/stata-master-dofile.do
@@ -13,10 +13,12 @@
   PART 1:  Install user-written packages and harmonize settings
 ********************************************************************************/
 
-    if (0) {
-        ssc install ietoolkit,  replace
-    }
-
+    local user_commands ietoolkit iefieldkit //Add required user-written commands
+    foreach command of local user_commands {
+        cap which `command'
+        if _rc == 111 ssc install `command'
+    }	
+	
 	*Harmonize settings accross users as much as possible
     ieboilstart, v(13.1)
     `r(version)'

--- a/code/stata-master-dofile.do
+++ b/code/stata-master-dofile.do
@@ -10,7 +10,7 @@
 *                PART 3:  Run do files                                         *
 *                                                                              *
 ********************************************************************************
-             PART 1:  Set standard settings and install packages
+  PART 1:  Install user-written packages and harmonize settings
 ********************************************************************************/
 
     if (0) {
@@ -21,7 +21,7 @@
     `r(version)'
 
 /*******************************************************************************
-              PART 2:  Prepare folder paths and define programs
+  PART 2:  Prepare folder paths and define programs
 *******************************************************************************/
 
     * Research Assistant folder paths
@@ -32,19 +32,19 @@
     }
 
 
-   * Baseline folder globals
-   global bl_encrypt       "${encrypted}/Round Baseline Encrypted"
-   global bl_dt            "${dropbox}/Baseline/DataSets"
-   global bl_doc           "${dropbox}/Baseline/Documentation"
-   global bl_do            "${github}/Baseline/Dofiles"
-   global bl_out           "${github}/Baseline/Output"
+    * Baseline folder globals
+    global bl_encrypt       "${encrypted}/Round Baseline Encrypted"
+    global bl_dt            "${dropbox}/Baseline/DataSets"
+    global bl_doc           "${dropbox}/Baseline/Documentation"
+    global bl_do            "${github}/Baseline/Dofiles"
+    global bl_out           "${github}/Baseline/Output"
 
 /*******************************************************************************
-                            PART 3: Run do files
+  PART 3: Run do files
 *******************************************************************************/
 
 /*------------------------------------------------------------------------------
-  PART 3.1:  De-identify baseline data
+    PART 3.1:  De-identify baseline data
 --------------------------------------------------------------------------------
  REQUIRES:   ${bl_encrypt}/Raw Identified Data/D4DI_baseline_raw_identified.dta
  CREATES:    ${bl_dt}/Raw Deidentified/D4DI_baseline_raw_deidentified.dta
@@ -53,7 +53,7 @@
     do "${bl_do}/Cleaning/deidentify.do"
 
 /*------------------------------------------------------------------------------
-  PART 3.2:  Clean baseline data
+    PART 3.2:  Clean baseline data
 --------------------------------------------------------------------------------
   REQUIRES:   ${bl_dt}/Raw Deidentified/D4DI_baseline_raw_deidentified.dta
   CREATES:    ${bl_dt}/Final/D4DI_baseline_clean.dta
@@ -63,7 +63,7 @@
     do "${bl_do}/Cleaning/cleaning.do"
 
 /*-----------------------------------------------------------------------------
- PART 3.3:  Construct income indicators
+    PART 3.3:  Construct income indicators
 --------------------------------------------------------------------------------
   REQUIRES:   ${bl_dt}/Final/D4DI_baseline_clean.dta
   CREATES:    ${bl_out}/Raw/D4DI_baseline_income_distribution.png


### PR DESCRIPTION
These updates solves #188 and does a few more edits.

This code example is now too long for one page. 

![image](https://user-images.githubusercontent.com/15911801/75283807-8478f880-57e1-11ea-8127-905a004ae0c8.png)

We currently have three do-file sections. _de-ientification_, _cleaning_ and _construct_. If we would remove one of them it would fit on one page in the eBook. We still do not know the format of the printed book.

Should we merge as is or remove one section?