### PR TITLE
pdf embedd - previosuly the pdf auto downloaded on mobiles

### DIFF
--- a/mkdocs/docs/index.md
+++ b/mkdocs/docs/index.md
@@ -8,6 +8,6 @@ It serves as a companion to the [DIME Wiki](https://dimewiki.worldbank.org)
 and is produced by [DIME Analytics](https://www.worldbank.org/en/research/dime/data-and-analytics).
 
 
-### Full book in PDF-format for download
+### Download the Book in PDF Format
 [Download from Github](https://github.com/worldbank/d4di/raw/master/mkdocs/docs/bookpdf/Data-for-Development-Impact.pdf)
 <iframe src="https://docs.google.com/gview?url=https://github.com/worldbank/d4di/raw/master/mkdocs/docs/bookpdf/Data-for-Development-Impact.pdf&amp;embedded=true" style="width:100%; height:1000px;"></iframe>

--- a/mkdocs/docs/index.md
+++ b/mkdocs/docs/index.md
@@ -10,4 +10,4 @@ and is produced by [DIME Analytics](https://www.worldbank.org/en/research/dime/d
 
 ### Full book in PDF-format for download
 [Download from Github](https://github.com/worldbank/d4di/raw/master/mkdocs/docs/bookpdf/Data-for-Development-Impact.pdf)
-<iframe src="./bookpdf/Data-for-Development-Impact.pdf#pagemode=none" width="100%" height="1000px"></iframe>
+<iframe src="https://docs.google.com/gview?url=https://github.com/worldbank/d4di/raw/master/mkdocs/docs/bookpdf/Data-for-Development-Impact.pdf&amp;embedded=true" style="width:100%; height:1000px;"></iframe>


### PR DESCRIPTION
Previously the pdf auto downloaded in mobile browser. This should prevent that so that user need to click the embedded view for it to download. 

Based on here https://medium.com/@kekayan/display-your-resume-cv-pdf-in-website-using-github-73a088ac961d and here https://webapps.stackexchange.com/a/78367

@bbdaniels , do not have `mkdocs` on my WB laptop. Can you push to gh-pages  from this branch and then I can try if it works?