### PR TITLE
Create chapters 1A and 1B

### DIFF
--- a/chapters/handling-data.tex
+++ b/chapters/handling-data.tex
@@ -35,202 +35,6 @@
 
 %------------------------------------------------
 
-\section{Protecting confidence in development research}
-
-The empirical revolution in development research\cite{angrist2017economic}
-has therefore led to increased public scrutiny of the reliability of research.\cite{rogers_2017}\index{transparency}\index{credibility}\index{reproducibility}
-Three major components make up this scrutiny: \textbf{reproducibility}\cite{duvendack2017meant}, \textbf{transparency},\cite{christensen2018transparency} and \textbf{credibility}.\cite{ioannidis2017power}
-Development researchers should take these concerns seriously.
-Many development research projects are purpose-built to address specific questions,
-and often use unique data or small samples.
-As a result, it is often the case that the data 
-researchers use for such studies has never been reviewed by anyone else,
-so it is hard for others to verify that it was 
-collected, handled, and analyzed appropriately.
-
-Reproducible and transparent methods are key to maintaining credibility 
-and avoiding serious errors. 
-This is particularly true for research that relies on original or novel data sources, 
-from innovative big data sources to surveys. 
-The field is slowly moving in the direction of requiring greater transparency. 
-Major publishers and funders, most notably the American Economic Association,
-have taken steps to require that code and data
-are accurately reported, cited, and preserved as outputs in themselves.\sidenote{
-	\url{https://www.aeaweb.org/journals/policies/data-code}}
-
-
-\subsection{Research reproducibility}
-
-Can another researcher reuse the same code on the same data 
-and get the exact same results as in your published paper?\sidenote{
-  \url{https://blogs.worldbank.org/impactevaluations/what-development-economists-talk-about-when-they-talk-about-reproducibility}}
-This is a standard known as \textbf{computational reproducibility}, 
-and it is an increasingly common requirement for publication.\sidenote{
-\url{https://www.nap.edu/resource/25303/R&R.pdf}})
-It is best practice to verify computational reproducibility before submitting a paper before publication. 
-This should be done by someone who is not on your research team, on a different computer, 
-using exactly the package of code and data files you plan to submit with your paper. 
-Code that is well-organized into a master script, and written to be easily run by others, 
-makes this task simpler. 
-The next chapter discusses organization of data work in detail. 
-
-For research to be reproducible, 
-all code files for data cleaning, construction and analysis
-should be public, unless they contain identifying information.
-Nobody should have to guess what exactly comprises a given index,
-or what controls are included in your main regression,
-or whether or not you clustered standard errors correctly.
-That is, as a purely technical matter, nobody should have to ``just trust you'',
-nor should they have to bother you to find out what happens
-if any or all of these things were to be done slightly differently.\cite{simmons2011false,simonsohn2015specification,wicherts2016degrees}
-Letting people play around with your data and code
-is a great way to have new questions asked and answered
-based on the valuable work you have already done.\sidenote{
-	\url{https://blogs.worldbank.org/opendata/making-analytics-reusable}}
-
-Making your research reproducible is also a public good.\sidenote{
-	\url{https://dimewiki.worldbank.org/Reproducible_Research}}
-It enables other researchers to re-use your code and processes
-to do their own work more easily and effectively in the future.
-This may mean applying your techniques to their data
-or implementing a similar structure in a different context.
-As a pure public good, this is nearly costless.
-The useful tools and standards you create will have high value to others.
-If you are personally or professionally motivated by citations,
-producing these kinds of resources can lead to that as well.
-Therefore, your code should be written neatly with clear instructions and published openly.
-It should be easy to read and understand in terms of structure, style, and syntax.
-Finally, the corresponding dataset should be openly accessible
-unless for legal or ethical reasons it cannot be.\sidenote{
-	\url{https://dimewiki.worldbank.org/Publishing_Data}}
-
-\subsection{Research transparency}
-
-Transparent research will expose not only the code,
-but all research processes involved in developing the analytical approach.\sidenote{
-	\url{https://www.princeton.edu/~mjs3/open_and_reproducible_opr_2017.pdf}}
-This means that readers are able to judge for themselves if the research was done well
-and the decision-making process was sound.
-If the research is well-structured, and all of the relevant documentation\sidenote{
-	\url{https://dimewiki.worldbank.org/Data_Documentation}}
-is shared, this makes it easy for the reader to understand the analysis later.
-Expecting process transparency is also an incentive for researchers to make better decisions,
-be skeptical and thorough about their assumptions,
-and, as we hope to convince you, make the process easier for themselves,
-because it requires methodical organization that is labor-saving over the complete course of a project.
-
-Tools like \textbf{pre-registration}\sidenote{
-	\url{https://dimewiki.worldbank.org/Pre-Registration}},
-\textbf{pre-analysis plans}\sidenote{
-	\url{https://dimewiki.worldbank.org/Pre-Analysis_Plan}},
-and \textbf{registered reports}\sidenote{
-	\url{https://blogs.worldbank.org/impactevaluations/registered-reports-piloting-pre-results-review-process-journal-development-economics}}
-can help with this process where they are available.\index{pre-registration}\index{pre-analysis plans}\index{Registered Reports}
-By pre-specifying a large portion of the research design,\sidenote{
-	\url{https://www.bitss.org/2019/04/18/better-pre-analysis-plans-through-design-declaration-and-diagnosis}}
-a great deal of analytical planning has already been completed,
-and at least some research questions are pre-committed for publication regardless of the outcome.
-This is meant to combat the ``file-drawer problem'',\cite{simonsohn2014p}
-and ensure that researchers are transparent in the additional sense that
-all the results obtained from registered studies are actually published.
-In no way should this be viewed as binding the hands of the researcher.\cite{olken2015promises}
-Anything outside the original plan is just as interesting and valuable
-as it would have been if the the plan was never published;
-but having pre-committed to any particular inquiry makes its results
-immune to a wide range of criticisms of specification searching or multiple testing.
-
-Documenting a project in detail greatly increases transparency.
-Many disciplines have a tradition of keeping a ``lab notebook'',
-and adapting and expanding this process to create a
-lab-style workflow in the development field is a
-critical step towards more transparent practices.
-This means explicitly noting decisions as they are made,
-and explaining the process behind the decision-making.
-Documentation on data processing and additional hypotheses tested
-will be expected in the supplemental materials to any publication.
-Careful documentation will also save the research team a lot of time during a project,
-as it prevents you from having the same discussion twice (or more!),
-since you have a record of why something was done in a particular way.
-There are a number of available tools
-that will contribute to producing documentation,
-\index{project documentation}
-but project documentation should always be an active and ongoing process,
-not a one-time requirement or retrospective task.
-New decisions are always being made as the plan begins contact with reality,
-and there is nothing wrong with sensible adaptation so long as it is recorded and disclosed.
-
-There are various software solutions for building documentation over time.
-The \textbf{Open Science Framework}\sidenote{\url{https://osf.io}} provides one such solution,\index{Open Science Framework}
-with integrated file storage, version histories, and collaborative wiki pages.
-\textbf{GitHub}\sidenote{\url{https://github.com}} provides a transparent documentation system\sidenote{
-	\url{https://dimewiki.worldbank.org/Getting_started_with_GitHub}},\index{task management}\index{GitHub}
-in addition to version histories and wiki pages.
-Such services offer multiple different ways
-to record the decision process leading to changes and additions,
-track and register discussions, and manage tasks.
-These are flexible tools that can be adapted to different team and project dynamics.
-Services that log your research process can show things like modifications made in response to referee comments, 
-by having tagged version histories at each major revision.
-They also allow you to use issue trackers
-to document the research paths and questions you may have tried to answer
-as a resource to others who have similar questions.
-Each project has specific requirements for data, code, and documentation management,
-and the exact transparency tools to use will depend on the team's needs,
-but they should be agreed upon prior to project launch.
-This way, you can start building a project's documentation as soon as you start making decisions.
-Email, however, is \textit{not} a note-taking service, because communications are rarely well-ordered,
-can be easily deleted, and are not available for future team members.
-
-\subsection{Research credibility}
-
-The credibility of research is traditionally a function of design choices.\cite{angrist2010credibility,ioannidis2005most}
-Is the research design sufficiently powered through its sampling and randomization?
-Were the key research outcomes pre-specified or chosen ex-post?
-How sensitive are the results to changes in specifications or definitions?
-Pre-analysis plans can be used to assuage these concerns for experimental evaluations
-\index{pre-analysis plan}
-by fully specifying some set of analysis intended to be conducted.
-Regardless of whether or not a formal pre-analysis plan is utilized,
-all experimental and observational studies should be pre-registered
-simply to create a record of the fact that the study was undertaken.\sidenote{\url{https://datacolada.org/12}}
-This is increasingly required by publishers and can be done very quickly
-using the \textbf{AEA} database,\sidenote{\url{https://www.socialscienceregistry.org}}
-the \textbf{3ie} database,\sidenote{\url{https://ridie.3ieimpact.org}}
-the \textbf{eGAP} database,\sidenote{\url{https://egap.org/content/registration}}
-or the \textbf{OSF} registry,\sidenote{\url{https://osf.io/registries}} as appropriate.
-\index{pre-registration}
-
-Common research standards from journals and funders feature both ex ante
-(or ``regulation'') and ex post (or ``verification'') policies.\cite{stodden2013toward}
-Ex ante policies require that authors bear the burden
-of ensuring they provide some set of materials before publication
-and their quality meet some minimum standard.
-Ex post policies require that authors make certain materials available to the public,
-but their quality is not a direct condition for publication.
-Still others have suggested ``guidance'' policies that would offer checklists
-for which practices to adopt, such as reporting on whether and how
-various practices were implemented.\cite{nosek2015promoting}
-
-With the ongoing rise of empirical research and increased public scrutiny of scientific evidence,
-simply making analysis code and data available
-is no longer sufficient on its own to guarantee that findings will hold their credibility.
-Even if your methods are highly precise,
-your evidence is only as good as your data --
-and there are plenty of mistakes that can be made between
-establishing a design and generating final results that would compromise its conclusions.
-That is why transparency is key for research credibility.
-It allows other researchers, and research consumers,
-to verify the steps to a conclusion by themselves,
-and decide whether their standards for accepting a finding as evidence are met.
-Therefore we encourage you to work, gradually, towards improving
-the documentation and release of your research materials,
-and finding the tools and workflows that best match your project and team.
-Every investment you make in documentation and transparency up front
-protects your project down the line, particularly as these standards continue to tighten.
-Since projects tend to span over many years,
-the records you will need to have available for publication are
-only bound to increase by the time you do so.
-
 
 %------------------------------------------------
 
@@ -247,7 +51,7 @@ individual people, households, villages, or firms that were part of data collect
 \index{data collection}
 This includes names, addresses, and geolocations, and extends to personal information
 such as email addresses, phone numbers, and financial information.\index{geodata}\index{de-identification}
-It is important to keep in mind data privacy principles not only for the  respondent 
+It is important to keep in mind data privacy principles not only for the  respondent
 but also the PII data of their household members or other individuals who are covered under the survey.
 \index{privacy}
 In some contexts this list may be more extensive --
@@ -281,7 +85,7 @@ Even if your research does not involve PII,
 it is a prerogative of the data owner to determine who may have access to it.
 Therefore, if you are using data that was provided to you by a partner,
 they have the right to request that you hold it to uphold the same data security safeguards as you would to PII.
-For the purposes of this book, 
+For the purposes of this book,
 we will call all any data that may not be freely accessed for these or other reasons \textbf{confidential data}.
 Given the increasing scrutiny on many organizations
 from recently advanced data rights and regulations,
@@ -319,16 +123,16 @@ It also means that they must explicitly and affirmatively consent
 to the collection, storage, and use of their information for any purpose.
 Therefore, the development of appropriate consent processes is of primary importance.
 All survey instruments must include a module in which the sampled respondent grants informed consent to participate.
-Research participants must be informed of the purpose of the research, 
+Research participants must be informed of the purpose of the research,
 what their participation will entail in terms of duration and any procedures,
-any foreseeable benefits or risks, 
+any foreseeable benefits or risks,
 and how their identity will be protected.\sidenote{
 	\url{https://www.icpsr.umich.edu/icpsrweb/content/datamanagement/confidentiality/conf-language.html}}
 There are special additional protections in place for vulnerable populations,
 such as minors, prisoners, and people with disabilities,
 and these should be confirmed with relevant authorities if your research includes them.
 
-IRB approval should be obtained well before any data is acquired. 
+IRB approval should be obtained well before any data is acquired.
 IRBs may have infrequent meeting schedules
 or require several rounds of review for an application to be approved.
 If there are any deviations from an approved plan or expected adjustments,
@@ -375,7 +179,7 @@ This means that is it usually not
 enough to rely service providers' on-the-fly encryption as they need to keep a copy
 of the decryption key to make it automatic. When confidential data is stored on a local
 computer it must always remain encrypted, and confidential data may never be sent unencrypted
-over email, WhatsApp, or other chat services. 
+over email, WhatsApp, or other chat services.
 
 The easiest way to reduce the risk of leaking confidential information is to use it as rarely as possible.
 It is often very simple to conduct planning and analytical work
@@ -424,10 +228,10 @@ once the data collection processes are completed.
 You can take simple steps to avoid risks by minimizing the handling of PII.
 First, only collect information that is strictly needed for the research.
 Second, avoid the proliferation of copies of identified data.
-There should never be more than one copy of the raw identified dataset in the project folder, 
+There should never be more than one copy of the raw identified dataset in the project folder,
 and it must always be encrypted.
-Even within the research team, 
-access to PII data should be limited to team members who require it for specific analysis 
+Even within the research team,
+access to PII data should be limited to team members who require it for specific analysis
 (most analysis will not depend on PII).
 Analysis that requires PII data is rare
 and can be avoided by properly linking identifiers to research information
@@ -444,11 +248,11 @@ will be re-linked to the data collected about them
 -- even if that data has had all directly identifying information removed --
 by using some other data that becomes identifying when analyzed together.
 For this reason, we recommend de-identification in two stages.
-The \textbf{initial de-identification} process strips the data of direct identifiers 
+The \textbf{initial de-identification} process strips the data of direct identifiers
 as early in the process as possible,
 to create a working de-identified dataset that
 can be shared \textit{within the research team} without the need for encryption.
-This simplifies workflows. 
+This simplifies workflows.
 The \textbf{final de-identification} process involves
 making a decision about the trade-off between
 risk of disclosure and utility of the data

--- a/chapters/reproducibility.tex
+++ b/chapters/reproducibility.tex
@@ -1,0 +1,232 @@
+%------------------------------------------------
+
+\begin{fullwidth}
+
+	Development research does not just involve real people -- it also affects real people.
+	Policy decisions are made every day using the results of briefs and studies,
+	and these can have wide-reaching consequences on the lives of millions.
+	As the range and importance of the policy-relevant questions asked by development researchers grow,
+	so too does the (rightful) scrutiny under which methods and results are placed.
+	It is useful to think of research as a public service,
+	one that requires you to be accountable to both research participants and research consumers.
+	On the research participant side,
+	it is essential to respect individual privacy and ensure data security.
+	Researchers look deeply into real people's personal lives, financial conditions, and other sensitive subjects.
+	Respecting the respondents' right to privacy,
+	by intelligently assessing and proactively averting risks they might face,
+	is a core tenet of research ethics.
+	On the consumer side, it is important to protect confidence in development research
+	by following modern practices for transparency and reproducibility.
+
+  Across the social sciences, the open science movement has been fueled by discoveries of low-quality research practices,
+	data and code that are inaccessible to the public, analytical errors in major research papers,
+	and in some cases even outright fraud. While the development research community has not yet
+	experienced any major scandals, it has become clear that there are necessary incremental improvements
+	in the way that code and data are handled as part of research.
+	Neither privacy nor transparency is an all-or-nothing objective:
+	the most important thing is to report the transparency and privacy measures you have taken
+  and always strive to do the best that you are capable of with current technology.
+	In this chapter, we outline a set of practices that help to ensure
+	research participants are appropriately protected and
+	research consumers can be confident in the conclusions reached.
+  Later chapters will provide more hands-on guides to implementing those practices.
+
+\end{fullwidth}
+
+%------------------------------------------------
+
+\section{Protecting confidence in development research}
+
+The empirical revolution in development research\cite{angrist2017economic}
+has therefore led to increased public scrutiny of the reliability of research.\cite{rogers_2017}\index{transparency}\index{credibility}\index{reproducibility}
+Three major components make up this scrutiny: \textbf{reproducibility}\cite{duvendack2017meant}, \textbf{transparency},\cite{christensen2018transparency} and \textbf{credibility}.\cite{ioannidis2017power}
+Development researchers should take these concerns seriously.
+Many development research projects are purpose-built to address specific questions,
+and often use unique data or small samples.
+As a result, it is often the case that the data
+researchers use for such studies has never been reviewed by anyone else,
+so it is hard for others to verify that it was
+collected, handled, and analyzed appropriately.
+
+Reproducible and transparent methods are key to maintaining credibility
+and avoiding serious errors.
+This is particularly true for research that relies on original or novel data sources,
+from innovative big data sources to surveys.
+The field is slowly moving in the direction of requiring greater transparency.
+Major publishers and funders, most notably the American Economic Association,
+have taken steps to require that code and data
+are accurately reported, cited, and preserved as outputs in themselves.\sidenote{
+	\url{https://www.aeaweb.org/journals/policies/data-code}}
+
+
+\subsection{Research reproducibility}
+
+Can another researcher reuse the same code on the same data
+and get the exact same results as in your published paper?\sidenote{
+  \url{https://blogs.worldbank.org/impactevaluations/what-development-economists-talk-about-when-they-talk-about-reproducibility}}
+This is a standard known as \textbf{computational reproducibility},
+and it is an increasingly common requirement for publication.\sidenote{
+\url{https://www.nap.edu/resource/25303/R&R.pdf}})
+It is best practice to verify computational reproducibility before submitting a paper before publication.
+This should be done by someone who is not on your research team, on a different computer,
+using exactly the package of code and data files you plan to submit with your paper.
+Code that is well-organized into a master script, and written to be easily run by others,
+makes this task simpler.
+The next chapter discusses organization of data work in detail.
+
+For research to be reproducible,
+all code files for data cleaning, construction and analysis
+should be public, unless they contain identifying information.
+Nobody should have to guess what exactly comprises a given index,
+or what controls are included in your main regression,
+or whether or not you clustered standard errors correctly.
+That is, as a purely technical matter, nobody should have to ``just trust you'',
+nor should they have to bother you to find out what happens
+if any or all of these things were to be done slightly differently.\cite{simmons2011false,simonsohn2015specification,wicherts2016degrees}
+Letting people play around with your data and code
+is a great way to have new questions asked and answered
+based on the valuable work you have already done.\sidenote{
+	\url{https://blogs.worldbank.org/opendata/making-analytics-reusable}}
+
+Making your research reproducible is also a public good.\sidenote{
+	\url{https://dimewiki.worldbank.org/Reproducible_Research}}
+It enables other researchers to re-use your code and processes
+to do their own work more easily and effectively in the future.
+This may mean applying your techniques to their data
+or implementing a similar structure in a different context.
+As a pure public good, this is nearly costless.
+The useful tools and standards you create will have high value to others.
+If you are personally or professionally motivated by citations,
+producing these kinds of resources can lead to that as well.
+Therefore, your code should be written neatly with clear instructions and published openly.
+It should be easy to read and understand in terms of structure, style, and syntax.
+Finally, the corresponding dataset should be openly accessible
+unless for legal or ethical reasons it cannot be.\sidenote{
+	\url{https://dimewiki.worldbank.org/Publishing_Data}}
+
+\subsection{Research transparency}
+
+Transparent research will expose not only the code,
+but all research processes involved in developing the analytical approach.\sidenote{
+	\url{https://www.princeton.edu/~mjs3/open_and_reproducible_opr_2017.pdf}}
+This means that readers are able to judge for themselves if the research was done well
+and the decision-making process was sound.
+If the research is well-structured, and all of the relevant documentation\sidenote{
+	\url{https://dimewiki.worldbank.org/Data_Documentation}}
+is shared, this makes it easy for the reader to understand the analysis later.
+Expecting process transparency is also an incentive for researchers to make better decisions,
+be skeptical and thorough about their assumptions,
+and, as we hope to convince you, make the process easier for themselves,
+because it requires methodical organization that is labor-saving over the complete course of a project.
+
+Tools like \textbf{pre-registration}\sidenote{
+	\url{https://dimewiki.worldbank.org/Pre-Registration}},
+\textbf{pre-analysis plans}\sidenote{
+	\url{https://dimewiki.worldbank.org/Pre-Analysis_Plan}},
+and \textbf{registered reports}\sidenote{
+	\url{https://blogs.worldbank.org/impactevaluations/registered-reports-piloting-pre-results-review-process-journal-development-economics}}
+can help with this process where they are available.\index{pre-registration}\index{pre-analysis plans}\index{Registered Reports}
+By pre-specifying a large portion of the research design,\sidenote{
+	\url{https://www.bitss.org/2019/04/18/better-pre-analysis-plans-through-design-declaration-and-diagnosis}}
+a great deal of analytical planning has already been completed,
+and at least some research questions are pre-committed for publication regardless of the outcome.
+This is meant to combat the ``file-drawer problem'',\cite{simonsohn2014p}
+and ensure that researchers are transparent in the additional sense that
+all the results obtained from registered studies are actually published.
+In no way should this be viewed as binding the hands of the researcher.\cite{olken2015promises}
+Anything outside the original plan is just as interesting and valuable
+as it would have been if the the plan was never published;
+but having pre-committed to any particular inquiry makes its results
+immune to a wide range of criticisms of specification searching or multiple testing.
+
+Documenting a project in detail greatly increases transparency.
+Many disciplines have a tradition of keeping a ``lab notebook'',
+and adapting and expanding this process to create a
+lab-style workflow in the development field is a
+critical step towards more transparent practices.
+This means explicitly noting decisions as they are made,
+and explaining the process behind the decision-making.
+Documentation on data processing and additional hypotheses tested
+will be expected in the supplemental materials to any publication.
+Careful documentation will also save the research team a lot of time during a project,
+as it prevents you from having the same discussion twice (or more!),
+since you have a record of why something was done in a particular way.
+There are a number of available tools
+that will contribute to producing documentation,
+\index{project documentation}
+but project documentation should always be an active and ongoing process,
+not a one-time requirement or retrospective task.
+New decisions are always being made as the plan begins contact with reality,
+and there is nothing wrong with sensible adaptation so long as it is recorded and disclosed.
+
+There are various software solutions for building documentation over time.
+The \textbf{Open Science Framework}\sidenote{\url{https://osf.io}} provides one such solution,\index{Open Science Framework}
+with integrated file storage, version histories, and collaborative wiki pages.
+\textbf{GitHub}\sidenote{\url{https://github.com}} provides a transparent documentation system\sidenote{
+	\url{https://dimewiki.worldbank.org/Getting_started_with_GitHub}},\index{task management}\index{GitHub}
+in addition to version histories and wiki pages.
+Such services offer multiple different ways
+to record the decision process leading to changes and additions,
+track and register discussions, and manage tasks.
+These are flexible tools that can be adapted to different team and project dynamics.
+Services that log your research process can show things like modifications made in response to referee comments,
+by having tagged version histories at each major revision.
+They also allow you to use issue trackers
+to document the research paths and questions you may have tried to answer
+as a resource to others who have similar questions.
+Each project has specific requirements for data, code, and documentation management,
+and the exact transparency tools to use will depend on the team's needs,
+but they should be agreed upon prior to project launch.
+This way, you can start building a project's documentation as soon as you start making decisions.
+Email, however, is \textit{not} a note-taking service, because communications are rarely well-ordered,
+can be easily deleted, and are not available for future team members.
+
+\subsection{Research credibility}
+
+The credibility of research is traditionally a function of design choices.\cite{angrist2010credibility,ioannidis2005most}
+Is the research design sufficiently powered through its sampling and randomization?
+Were the key research outcomes pre-specified or chosen ex-post?
+How sensitive are the results to changes in specifications or definitions?
+Pre-analysis plans can be used to assuage these concerns for experimental evaluations
+\index{pre-analysis plan}
+by fully specifying some set of analysis intended to be conducted.
+Regardless of whether or not a formal pre-analysis plan is utilized,
+all experimental and observational studies should be pre-registered
+simply to create a record of the fact that the study was undertaken.\sidenote{\url{https://datacolada.org/12}}
+This is increasingly required by publishers and can be done very quickly
+using the \textbf{AEA} database,\sidenote{\url{https://www.socialscienceregistry.org}}
+the \textbf{3ie} database,\sidenote{\url{https://ridie.3ieimpact.org}}
+the \textbf{eGAP} database,\sidenote{\url{https://egap.org/content/registration}}
+or the \textbf{OSF} registry,\sidenote{\url{https://osf.io/registries}} as appropriate.
+\index{pre-registration}
+
+Common research standards from journals and funders feature both ex ante
+(or ``regulation'') and ex post (or ``verification'') policies.\cite{stodden2013toward}
+Ex ante policies require that authors bear the burden
+of ensuring they provide some set of materials before publication
+and their quality meet some minimum standard.
+Ex post policies require that authors make certain materials available to the public,
+but their quality is not a direct condition for publication.
+Still others have suggested ``guidance'' policies that would offer checklists
+for which practices to adopt, such as reporting on whether and how
+various practices were implemented.\cite{nosek2015promoting}
+
+With the ongoing rise of empirical research and increased public scrutiny of scientific evidence,
+simply making analysis code and data available
+is no longer sufficient on its own to guarantee that findings will hold their credibility.
+Even if your methods are highly precise,
+your evidence is only as good as your data --
+and there are plenty of mistakes that can be made between
+establishing a design and generating final results that would compromise its conclusions.
+That is why transparency is key for research credibility.
+It allows other researchers, and research consumers,
+to verify the steps to a conclusion by themselves,
+and decide whether their standards for accepting a finding as evidence are met.
+Therefore we encourage you to work, gradually, towards improving
+the documentation and release of your research materials,
+and finding the tools and workflows that best match your project and team.
+Every investment you make in documentation and transparency up front
+protects your project down the line, particularly as these standards continue to tighten.
+Since projects tend to span over many years,
+the records you will need to have available for publication are
+only bound to increase by the time you do so.

--- a/manuscript.tex
+++ b/manuscript.tex
@@ -28,11 +28,21 @@
 \input{chapters/introduction.tex}
 
 %----------------------------------------------------------------------------------------
-%	CHAPTER 1
+%	CHAPTER 1A (for now)
 %----------------------------------------------------------------------------------------
 
 
-\chapter{Chapter 1: Handling data ethically}
+\chapter{Chapter 1A: Research reproducibility, transparency, and credibility}
+\label{ch:1}
+
+\input{chapters/reproducibility.tex}
+
+%----------------------------------------------------------------------------------------
+%	CHAPTER 1B (for now)
+%----------------------------------------------------------------------------------------
+
+
+\chapter{Chapter 1B: Handling data securely}
 \label{ch:1}
 
 \input{chapters/handling-data.tex}


### PR DESCRIPTION
This sets up Chapter 1A and 1B so they can be edited without causing conflicts later, for #425. It creates issues in chapter numbering and the TOC spills over but this will happen anyway until it gets cleaned up at the end.