### PR TITLE
ch data acquisition - restructure section: handle data securely

### DIFF
--- a/chapters/data-collection.tex
+++ b/chapters/data-collection.tex
@@ -110,7 +110,8 @@ Rather, they must enter into data licensing agreements
 to access the data and publish derivative work. 
 These agreements should make clear from the outset whether the 
 research team can make the original data, any portion thereof, or derivatives\sidenote{
-	\textbf{Derivatives} of a data can be indicators, aggregates etc. based on the data.} 
+	\textbf{Derivatives} of a data can be indicators, aggregates, 
+	visualizations etc. based on the data.} 
 of the data, public. 
 
 Data ownership\sidenote{need to add DIME Wiki page} can be challenging to establish,

--- a/chapters/data-collection.tex
+++ b/chapters/data-collection.tex
@@ -651,20 +651,20 @@ and should be what you use on a day-to-day basis.
 The most common reason a data is confidential is that it includes personal identifiers. 
 Removing identifying information is called de-identification,
 and we will discuss how to do that in the next chapter. 
-De-identifying the data, at the earliest possible opportunity 
+De-identifying the data at the earliest possible opportunity 
 will simplify the workflow without compromising data security,
-as de-identified data no longer must be encrypted.
-Another method of making data less confidential is to aggregate the data, 
+as de-identified data no longer needs to be encrypted.
+Another method to protect confidential data is to aggregate the data, 
 meaning that sums and averages of group of observations are calculated
 and only those numbers are reported.
 Any of these techniques can be used either before the data is shared with the research team,
 or when creating the second non-confidential version of the data set to be used in the analysis.
-If confidential information is directly required for the analysis itself,
+If confidential information is directly required for the analysis,
 it will be necessary to keep at least a subset of the data encrypted through the data analysis process.
 
-There are multiple options on how to share data encrypted. 
+There are multiple options for sharing encrypted data. 
 If you need to collaborate on a confidential data set 
-then you can create an encrypted folders using VeraCrypt as described above.
+then you can create an encrypted folder, for example using VeraCrypt (as described above).
 An encrypted folder can be shared the same way you share a normal file
 and it can even be shared using insecure modes of communication
 such as email or third-party syncing services.
@@ -673,9 +673,9 @@ can read and collaborate on the encrypted file.
 
 If you only need a one-time transfer of a confidential dataset, 
 for example when receiving data from a partner organization,
-then the setting up of an encrypted folder
+then setting up an encrypted folder
 might not be your best option or even feasible.
-Instead, for one-time transfers you can send data over password protected
+Instead, for one-time transfers we recommend sending data over password-protected
 end-to-end encrypted file sharing services.\sidenote{
 	One such service at the time of writing is https://send.firefox.com/} 
 

--- a/chapters/data-collection.tex
+++ b/chapters/data-collection.tex
@@ -670,10 +670,9 @@ such as email or third-party syncing services.
 Anyone who has access to both the encrypted folder and the encryption key
 can read and collaborate on the encrypted file.
 
-If you only need a one-time transfer of a confidential dataset, 
-for example when receiving data from a partner organization,
-then setting up an encrypted folder
-might not be your best option or even feasible.
+If you only need a one-time transfer of confidential information,
+such as to receive a data set from a partner organization, 
+then setting up a permanent encrypted folder may be unnecessary.
 Instead, for one-time transfers we recommend sending data over password-protected
 end-to-end encrypted file sharing services.\sidenote{
 	One such service at the time of writing is https://send.firefox.com/} 

--- a/chapters/data-collection.tex
+++ b/chapters/data-collection.tex
@@ -478,6 +478,9 @@ common reasons are that it contains personally identifiable information (PII)\si
   \url{https://dimewiki.worldbank.org/Personally\_Identifiable\_Information\_(PII)}}
 or that the data owner has specified restricted access.
 
+
+\subsection{Encryption}
+
 \index{encryption}\textbf{Data encryption} is central to secure data handling. 
 Data encryption is a group of methods that ensure that files are unreadable 
 even if laptops are stolen, servers are hacked, 
@@ -492,30 +495,62 @@ so that it is easy as possible to make sure the weakest link is still sufficient
 
 Encrypted data is made readable again using decryption,
 and decryption requires a password or a key.
+Encryption make data files completely unusable to anyone without the specific decryption key, 
+which is a higher level of security than password-protection.
+There are two main types of encryption algorithms called
+\textbf{symmetric encryption}\sidenote{
+	\url{https://dimewiki.worldbank.org/Encryption\#Symmetric\_Encryption}}
+and \textbf{asymmetric encryption}\sidenote{
+	\url{https://dimewiki.worldbank.org/Encryption\#Asymmetric\_Encryption}}.
+The only difference you need to know is that in symmetric encryption,
+the same key is used to both encrypt and decrypt the data,
+while in asymmetric encryption, 
+one key in a key pair is used to encrypt the data, 
+and the other key in the same pair is used to decrypt it.
+We will show how this difference can be utilized in your encryption work flow.
+
 It is never secure to share passwords or keys by email,
 WhatsApp or other insecure modes of communication;
 instead, use a secure password manager.\sidenote{
-  \url{https://lastpass.com} or \url{https://bitwarden.com}
-  among many other.}
+	\url{https://lastpass.com} or \url{https://bitwarden.com}
+	among many other.}
 In addition to providing a way to securely share passwords,
 password managers also provide a secure location
 for long term storage for passwords and keys, whether they are shared or not.
+Make sure you store your keys with descriptive names to match the encryption to which they correspond.
 
-Many data-sharing software providers will promote their services
+Finally, there are also two contexts for encryption you should be aware of;
+\textbf{encryption-in-transit}\sidenote{
+	\url{https://dimewiki.worldbank.org/Encryption\#Encryption\_in\_Transit}}
+and \textbf{encryption-at-rest}\sidenote{
+	\url{https://dimewiki.worldbank.org/Encryption\#Encryption\_at\_Rest}}.
+Encryption-in-transit protects your data when in transit over the internet. 
+It is easy to implement so that it does not require input from the user, 
+as the servers involved can hold the keys for the short time they are used
+before they are thrown away.
+Therefore you rarely need to worry about this,
+as long as you are using well established services.
+Encryption-at-rest protects your data when it is stored on a server or your computer.
+Since the storage time is longer than instantaneous,
+you as a user, need to keep track of the key. 
+Anyone with access to the key has access to the sensitive data.
+If you do not, the raw data will be accessible by
+individuals who are not approved by your IRB,
+such as tech support personnel,
+server administrators, and other third-party staff.
+
+Many data-sharing and data-storage software providers will promote their services
 by advertising on-the-fly encryption and decryption.
-While useful, on-the-fly encryption is never sufficient for securing confidential data.
-In order to automate on-the-fly encryption,
-the service provider needs to keep a copy of the password or key.
-This implies the service provider has access to the data.
-This is the case for all file syncing software such as Dropbox,
-which, in addition to being able to view your data, may require
-additional legal usage rights in order to host it on their servers.
+However, often this is only encryption-in-transit and not encryption-at-rest.
+Sometimes on-the-fly encryption involves encryption-at-rest, 
+but then you have to verify how the encryption key is handled.
 It is possible, in some enterprise versions of data sharing software,
 to set up appropriately secure on-the-fly encryption.
 However, that setup is advanced, and you should never trust it
 unless a cybersecurity expert within your organization
 has specified what it can be used for.
-In all other cases you should follow the steps laid out in this section.
+In all other cases you should follow the steps laid out in this section,
+where you set up your own encryption where you can be sure who has access to the key.
 
 
 \subsection{Collecting data securely}

--- a/chapters/data-collection.tex
+++ b/chapters/data-collection.tex
@@ -665,8 +665,7 @@ it will be necessary to keep at least a subset of the data encrypted through the
 There are multiple options for sharing encrypted data. 
 If you need to collaborate on a confidential data set 
 then you can create an encrypted folder, for example using VeraCrypt (as described above).
-An encrypted folder can be shared the same way you share a normal file
-and it can even be shared using insecure modes of communication
+An encrypted folder can safely be shared using insecure modes of communication 
 such as email or third-party syncing services.
 Anyone who has access to both the encrypted folder and the encryption key
 can read and collaborate on the encrypted file.

--- a/chapters/data-collection.tex
+++ b/chapters/data-collection.tex
@@ -553,39 +553,36 @@ In all other cases you should follow the steps laid out in this section,
 where you set up your own encryption where you can be sure who has access to the key.
 
 
-\subsection{Collecting data securely}
-Generating data through surveys requires special considerations for data security.
-Most common data collection software will automatically encrypt
-all data in transit (i.e., upload from field or download from server).\sidenote{
-  \url{https://dimewiki.worldbank.org/Encryption\#Encryption\_in\_Transit}}
-If this is implemented by the software you are using,
-then your data will be encrypted from the time it leaves the device
-(in tablet-assisted data collection) or browser (in web data collection),
-until it reaches the server.
-Therefore, as long as you are using an established survey software,
-this step is largely taken care of.
-However, the research team must ensure that all computers, tablets,
-and accounts that are used in data collection have a secure logon
-password and are never left unlocked.
+\subsection{Storing data securely}
+% doesn't cover 'big' data
+The first thing you need to do before planning how to securely receive data, 
+is to plan how to securely store data after you have received it.
+You can either store your data on your computer or in a cloud storage.
 
-Encryption-in-transit means that data is safe while it is being transmitted,
-but it is not automatically secure when it is being stored.
-\textbf{Encryption-at-rest}\sidenote{
-  \url{https://dimewiki.worldbank.org/Encryption\#Encryption\_at\_Rest}}
-is necessary to ensure that confidential data are private when stored on a cloud server.
-You must keep your data encrypted on the data collection server whenever PII is collected,
-or when this is required by the data sharing agreement.
-If you do not, the raw data will be accessible by
-individuals who are not approved by your IRB,
-such as tech support personnel,
-server administrators, and other third-party staff.
-Encryption-at-rest must be used to make
-data files completely unusable to anyone without the specific decryption key 
--- a higher level of security than password-protection.
-Encryption-at-rest requires active participation from the user,
-and you should be fully aware that if your decryption key is lost,
-there is absolutely no way to recover your data.
+You need to both be able to add data to your secure storage
+and access it when you want to work with it.
+That is a perfect use case for \textbf{symmetric encryption} 
+where the same key is used to both encrypt and decrypt your files.
+Think of this as a physical safe where you have one key 
+used to both add content and access content.
 
+The equivalent to a safe in secure data storage is an encrypted folder,
+and you can set them up using, for example, VeraCrypt.\sidenote{
+	\url{https://www.veracrypt.fr} and
+	\url{https://github.com/worldbank/dime-standards/blob/master/dime-research-standards/pillar-4-data-security/data-security-resources/veracrypt-guidelines.md}}
+Files in an encrypted folder can be interacted with and modified like any unencrypted file,
+as long as you have the key.
+This is an implementation of encryption-at-rest
+There is absolutely no way to restore your data if you were to lose your key, 
+so we cannot stress enough the importance of using a password manager,
+or equally secure solution, to store your key.
+
+It is becoming more and more common that development research
+is done on data set that is too big to store on a regular computer,
+and instead the data is stored and processed in a cloud environment. 
+There are many available cloud storage solutions
+and you need to understand how the data is encrypted and how the keys are handled.
+This is likely another case where a regular research team will have to ask a cybersecurity expert.
 You should not assume that your data is encrypted-at-rest by default.
 In most data collection platforms,
 encryption-at-rest needs to be explicitly enabled and operated by the user.

--- a/chapters/data-collection.tex
+++ b/chapters/data-collection.tex
@@ -619,23 +619,55 @@ from the field, to also send confidential data,
 such as an identifying list of respondents, to the field.
 
 
-\subsection{Storing data securely}
-% doesn't cover 'big' data
-For analysis, you will need to transfer the data from the data collection software to
-a secure location on your computer or a cloud drive.
-Instead, at this stage you need \textbf{symmetric encryption}\sidenote{
-  \url{https://dimewiki.worldbank.org/Encryption\#Symmetric\_Encryption}}.
-In this set-up, a single key is used to both encrypt and decrypt the information.
-Since only one key is used, the workflow can be simplified:
-re-encryption after decrypted access can be done automatically,
-and the same secure folder can be used for multiple files.
-Data should be stored in an encrypted folder,
-using, for example, VeraCrypt.\sidenote{
-	\url{https://www.veracrypt.fr} and \url{https://github.com/worldbank/dime-standards/blob/master/dime-research-standards/pillar-4-data-security/data-security-resources/veracrypt-guidelines.md}}
-These files can be interacted with and modified like any unencrypted file,
- as long as you have the key.
-The following workflow allows you to receive data and store it securely,
-without compromising data security:
+\subsection{Receiving or sharing data securely}
+
+If you receive confidential data from a partner organization 
+or share confidential data with your research team over the internet,
+it must always be encrypted.  
+The best practice to reduce the amount of confidential data shared or transfer.
+If you do not need the confidential information you will simplify your workflow
+by not collecting or reviving confidential data in the first place.
+This should always be your first option when possible.
+
+Usually we need to deal with confidential data at some point in the project, 
+and then the second best practice is create two versions of your data. 
+One version of your data will still have the confidential information,
+and it will need to be encrypted at all times. 
+This version should only be used when the confidential information is actually needed.
+In the second version of the data all confidential data should be removed,
+and this version does not have to be encrypted 
+and should be the data that you use on a day-to-day basis.
+
+The most common reason a data is confidential is that it includes personal identifiers. 
+Removing identifying information is called de-identification,
+and we will discuss how to do that in the next chapter. 
+De-identifying the data, at the earliest possible opportunity 
+will simplify the workflow without compromising data security.
+Another method of making data less confidential is to aggregate the data, 
+meaning that we calculate sums and averages of group of observation and report only those numbers.
+Any of these techniques can be used either before the data is shared with the research team,
+or when creating the second non-confidential version of the data set to be used in the analysis.
+If confidential information is directly required for the analysis itself,
+it will be necessary to keep at least a subset of the data encrypted through the data analysis process.
+The data that is no longer confidential does no longer need to be encrypted when shared.
+
+There are multiple options on how to share data encrypted. 
+If you need to collaborate on a confidential data set 
+then you can create an encrypted folders using VeraCrypt as described above.
+An encrypted folder can be shared the same way you share a normal file
+and it can even be shared shared using insecure modes of communication
+such as email or third-party syncing services.
+Anyone who has access to both the encrypted folder and the encryption key
+can read and collaborate on the encrypted file.
+
+If you only need a one-time transfer of a confidential data set, 
+for example when receving data from a partner organization,
+then the setting up an encrypted folder might not be feasible.
+Instead, for one-time transfers you can send data over password protected end-to-end encrypted file sharing services.\sidenote{
+	One such service at the time of writing is https://send.firefox.com/} 
+
+
+
 
 \begin{enumerate}
 	\item Create a secure encrypted folder in your project folder.

--- a/chapters/data-collection.tex
+++ b/chapters/data-collection.tex
@@ -611,6 +611,12 @@ and you should never decrypt it until it is downloaded on your computer.
 If your data collection service allows you to browse data in the browser, 
 then the encryption is only implemented correctly if you are asked for the key each time.
 
+Finally, the data security standards that apply when receiving confidential data from the field
+also apply when transferring confidential data to the field.
+In some survey software, 
+you can use the same encryption that allows you to receive data securely
+from the field, to also send confidential data,
+such as an identifying list of respondents, to the field.
 
 
 \subsection{Storing data securely}

--- a/chapters/data-collection.tex
+++ b/chapters/data-collection.tex
@@ -56,13 +56,11 @@ Research teams granted access to existing data may receive that data in a number
 You may receive access to an existing server, 
 or physical access to extract certain information, 
 or a one-time transfer of a block of data.
-In all cases, you must take action to ensure that data is transferred through 
+In all cases, you must take action to ensure 
+that data is transferred through 
 secure channels so that confidential data is not compromised.
-Talk to an information-technology specialist,
-either at your organization or at the partner organization,
-to ensure that data is being transferred, received, and stored
-in a method that conforms to the relevant level of security.
-Keep in mind that compliance with ethical standards may 
+See the section \textit{Handling data securely} later in this chapter for how to do that.
+Keep in mind that compliance with ethical research standards may 
 in some cases require a stricter level of security than initially proposed by the partner agency.
 
 At this stage, it is very important to assess

--- a/chapters/data-collection.tex
+++ b/chapters/data-collection.tex
@@ -493,89 +493,94 @@ Encryption should be seen as a system that is only as secure as its weakest link
 This section recommends a streamlined workflow,
 so that it is easy as possible to make sure the weakest link is still sufficiently secure.
 
-Encrypted data is made readable again using decryption,
+Data that has been encrypted is made readable again using decryption,
 and decryption requires a password or a key.
 Encryption make data files completely unusable to anyone without the specific decryption key, 
 which is a higher level of security than password-protection.
-There are two main types of encryption algorithms called
-\textbf{symmetric encryption}\sidenote{
-	\url{https://dimewiki.worldbank.org/Encryption\#Symmetric\_Encryption}}
-and \textbf{asymmetric encryption}\sidenote{
-	\url{https://dimewiki.worldbank.org/Encryption\#Asymmetric\_Encryption}}.
-The only difference you need to know is that in symmetric encryption,
-the same key is used to both encrypt and decrypt the data,
-while in asymmetric encryption, 
-one key in a key pair is used to encrypt the data, 
-and the other key in the same pair is used to decrypt it.
-We will show how this difference can be utilized in your encryption work flow.
-
 It is never secure to share passwords or keys by email,
 WhatsApp or other insecure modes of communication;
 instead, use a secure password manager.\sidenote{
 	\url{https://lastpass.com} or \url{https://bitwarden.com}
-	among many other.}
+	among many other. See DIME Analytics' guide to password managers here: \url{
+		https://github.com/worldbank/dime-standards/blob/master/dime-research-standards/pillar-4-data-security/data-security-resources/password-manager-guidelines.md
+}}
 In addition to providing a way to securely share passwords,
 password managers also provide a secure location
 for long term storage for passwords and keys, whether they are shared or not.
 Make sure you store your keys with descriptive names to match the encryption to which they correspond.
 
-Finally, there are also two contexts for encryption you should be aware of;
+There are two main types of encryption algorithms and they are called
+\textbf{symmetric encryption}\sidenote{
+	\url{https://dimewiki.worldbank.org/Encryption\#Symmetric\_Encryption}}
+and \textbf{asymmetric encryption}\sidenote{
+	\url{https://dimewiki.worldbank.org/Encryption\#Asymmetric\_Encryption}}.
+The only difference you need to know is that the same key is used to both 
+encrypt and decrypt the data in symmetric encryption,
+while in asymmetric encryption, 
+one key in a key pair is used to encrypt the data, 
+and the other key in the same pair is used to decrypt it.
+We will show how this difference can be utilized for different use cases common in research.
+
+
+Additionally, there are two contexts for encryption you should be aware of;
 \textbf{encryption-in-transit}\sidenote{
 	\url{https://dimewiki.worldbank.org/Encryption\#Encryption\_in\_Transit}}
 and \textbf{encryption-at-rest}\sidenote{
 	\url{https://dimewiki.worldbank.org/Encryption\#Encryption\_at\_Rest}}.
 Encryption-in-transit protects your data when in transit over the internet. 
-It is easy to implement so that it does not require input from the user, 
-as the servers involved can hold the keys for the short time they are used
-before they are thrown away.
-Therefore you rarely need to worry about this,
-as long as you are using well established services.
-Encryption-at-rest protects your data when it is stored on a server or your computer.
-Since the storage time is longer than instantaneous,
+It is easy to implement encryption-in-transit such that no input from the user is required,
+since the server and browser can keep track of the key for the short duration of the connection.
+All well established services have this implemented and you rarely have to worry about it.
+However, if you were to use a less well-known service,
+it is important that you verify that it use encryption-in-transit,
+as without it, your data and credentials are very vulnerable.
+Encryption-at-rest protects your data when it is stored somewhere, 
+for example on a server or on your computer.
+In contrast to encryption-in-transit, 
 you as a user, need to keep track of the key. 
-Anyone with access to the key has access to the confidential data.
+Only people listed on your IRB is allowed to have access to this file.
 If you do not, the raw data will be accessible by
-individuals who are not approved by your IRB,
-such as tech support personnel,
-server administrators, and other third-party staff.
 
 Many data-sharing and data-storage software providers will promote their services
 by advertising on-the-fly encryption and decryption.
-However, often this is only encryption-in-transit and not encryption-at-rest.
+However, this is often only encryption-in-transit and not encryption-at-rest.
 Sometimes on-the-fly encryption involves encryption-at-rest, 
-but then you have to verify how the encryption key is handled.
+but then you have to verify how the encryption key is handled
+as individuals who are not approved by your IRB,
+such as tech support personnel,
+server administrators, and other third-party staff 
+are not allowed to have access to the key.
 It is possible, in some enterprise versions of data sharing software,
 to set up appropriately secure on-the-fly encryption.
 However, that setup is advanced, and you should never trust it
 unless a cybersecurity expert within your organization
 has specified what it can be used for.
 In all other cases you should follow the steps laid out in this section,
-where you set up your own encryption where you can be sure who has access to the key.
+where you set up your own encryption 
+where you are in full control of who has access to the key.
 
 
 \subsection{Storing data securely}
 % doesn't cover 'big' data
 The first thing you need to do before planning how to securely receive data, 
 is to plan how to securely store data after you have received it.
-You can either store your data on your computer or in a cloud storage.
-
-You need to both be able to add data to your secure storage
-and access it when you want to work with it.
+Typically, you want to store your data so that you can decrypt and access it, 
+interact with it and then decrypt it again. 
 That is a perfect use case for \textbf{symmetric encryption} 
 where the same key is used to both encrypt and decrypt your files.
 Think of this as a physical safe where you have one key 
 used to both add content and access content.
 
 The equivalent to a safe in secure data storage is an encrypted folder,
-and you can set them up using, for example, VeraCrypt.\sidenote{
+which you can set up using, for example, VeraCrypt.\sidenote{
 	\url{https://www.veracrypt.fr} and
 	\url{https://github.com/worldbank/dime-standards/blob/master/dime-research-standards/pillar-4-data-security/data-security-resources/veracrypt-guidelines.md}}
 Files in an encrypted folder can be interacted with and modified like any unencrypted file,
 as long as you have the key.
-This is an implementation of encryption-at-rest
+This is an implementation of encryption-at-rest.
 There is absolutely no way to restore your data if you were to lose your key, 
 so we cannot stress enough the importance of using a password manager,
-or equally secure solution, to store your key.
+or equally secure solution, to store your keys.
 
 It is becoming more and more common that development research
 is done on data set that is too big to store on a regular computer,
@@ -583,30 +588,34 @@ and instead the data is stored and processed in a cloud environment.
 There are many available cloud storage solutions
 and you need to understand how the data is encrypted and how the keys are handled.
 This is likely another case where a regular research team will have to ask a cybersecurity expert.
+After someone have helped you to set up a secure cloud storage, 
+if you were to download a sample of the data --
+for example to develop your code on --
+then you need to remember to encrypt the data when stored on your computer.
 
 \subsection{Collecting data securely in the field}
 
 All common data collection software will automatically encrypt
 all data in transit (i.e., upload from field or download from server).
 However, it is also necessary to ensure that confidential data 
-are private when stored on a cloud server.
+are protected when stored on a server owned by the data collection software provider.
 You should not assume that your data is encrypted-at-rest by default.
 In most data collection platforms,
 encryption-at-rest needs to be explicitly enabled and operated by the user.
 
-When collecting data you want the tablets or the browsers used to collect data
+When collecting data you want the tablets or the browsers used for data collection
 to be able to encrypt all information before submitting it to the server. 
 At the same time you do not want those devices to have any way of decrypting already submitted data.
 This is a perfect use case for \textbf{asymmetric encryption}
 where there are two keys in a public/private key pair.
-The public key can safely be sent to all tablet or the browser to be used for encrypting the data.
-Only the private key in the same key pair can be used to decrypt that data.
-The private key should be kept secret and not be shared with anyone not listed on the IRB.
+The public key can safely be sent to all tablets or browsers to be used for encrypting the data.
+Only the private key in the same key pair can then be used to decrypt that data.
+The private key should be kept secret and should not be shared with anyone not listed on the IRB.
 Again, you must store the key pair in a secure location, 
 such as in a secure note in a password manager,
 as there is no way to access your data if the private key is lost.
 
-Data secured this way can securely pass through the server owned by the data collection software provider,
+Data encrypted this way can securely pass through the server owned by the data collection software provider,
 and you should never decrypt it until it is downloaded on your computer.
 If your data collection service allows you to browse data in the browser, 
 then the encryption is only implemented correctly if you are asked for the key each time.
@@ -624,9 +633,10 @@ such as an identifying list of respondents, to the field.
 If you receive confidential data from a partner organization 
 or share confidential data with your research team over the internet,
 it must always be encrypted.  
-The best practice to reduce the amount of confidential data shared or transfer.
+The best practice is to reduce the amount of confidential data
+needed to be shared or transfer.
 If you do not need the confidential information you will simplify your workflow
-by not collecting or reviving confidential data in the first place.
+by collecting or receiving data without any confidential information in the first place.
 This should always be your first option when possible.
 
 Usually we need to deal with confidential data at some point in the project, 
@@ -634,36 +644,39 @@ and then the second best practice is create two versions of your data.
 One version of your data will still have the confidential information,
 and it will need to be encrypted at all times. 
 This version should only be used when the confidential information is actually needed.
-In the second version of the data all confidential data should be removed,
-and this version does not have to be encrypted 
-and should be the data that you use on a day-to-day basis.
+In the second version of your data all confidential data should be removed.
+This version does not have to be encrypted 
+and should be what you use on a day-to-day basis.
 
 The most common reason a data is confidential is that it includes personal identifiers. 
 Removing identifying information is called de-identification,
 and we will discuss how to do that in the next chapter. 
 De-identifying the data, at the earliest possible opportunity 
-will simplify the workflow without compromising data security.
+will simplify the workflow without compromising data security,
+as de-identified data no longer must be encrypted.
 Another method of making data less confidential is to aggregate the data, 
-meaning that we calculate sums and averages of group of observation and report only those numbers.
+meaning that sums and averages of group of observations are calculated
+and only those numbers are reported.
 Any of these techniques can be used either before the data is shared with the research team,
 or when creating the second non-confidential version of the data set to be used in the analysis.
 If confidential information is directly required for the analysis itself,
 it will be necessary to keep at least a subset of the data encrypted through the data analysis process.
-The data that is no longer confidential does no longer need to be encrypted when shared.
 
 There are multiple options on how to share data encrypted. 
 If you need to collaborate on a confidential data set 
 then you can create an encrypted folders using VeraCrypt as described above.
 An encrypted folder can be shared the same way you share a normal file
-and it can even be shared shared using insecure modes of communication
+and it can even be shared using insecure modes of communication
 such as email or third-party syncing services.
 Anyone who has access to both the encrypted folder and the encryption key
 can read and collaborate on the encrypted file.
 
-If you only need a one-time transfer of a confidential data set, 
-for example when receving data from a partner organization,
-then the setting up an encrypted folder might not be feasible.
-Instead, for one-time transfers you can send data over password protected end-to-end encrypted file sharing services.\sidenote{
+If you only need a one-time transfer of a confidential dataset, 
+for example when receiving data from a partner organization,
+then the setting up of an encrypted folder
+might not be your best option or even feasible.
+Instead, for one-time transfers you can send data over password protected
+end-to-end encrypted file sharing services.\sidenote{
 	One such service at the time of writing is https://send.firefox.com/} 
 
 
@@ -675,11 +688,12 @@ you also need to protect your data from being accidentally over-written or delet
 This is done through a back-up protocol. This is an example of such a protocol:
 
 \begin{enumerate}
-	\item Create a encrypted folder in your project folder.
+	\item Create an encrypted folder in your project folder.
 	This should be on your computer, and could be in a shared folder.
 	
-	\item Download data from the data collection server to that encrypted folder.
-	If you encrypted the data during data collection, you will need \textit{both} the
+	\item Download your original data from your data source to that encrypted folder.
+	If your data source is a survey and the data was encrypted during data collection,
+	then you will need \textit{both} the
 	private key used during data collection to be able to download the data,
 	\textit{and} the key used when you created the encrypted folder to save it there.
 	This your first copy of your raw data, and the copy you will use in your cleaning and analysis.
@@ -688,11 +702,12 @@ This is done through a back-up protocol. This is an example of such a protocol:
 	Copy the data you just downloaded to this second encrypted folder.
 	This is the ``master'' backup copy of the raw data. 
 	You should never work with this data on a day-to-day basis.
-	You should not use the same encrypted folder or the same key, 
+	You should not use the same encrypted folder or the same key as above, 
 	because if you use the same key and lose the key, 
 	then you will have lost access to both encrypted folders. 
 	If you have an physical safe where you can securely store the external drive, 
-	then you do not need to encrypt the data and thereby do not risk losing access by losing an encryption key.
+	then you do not need to encrypt the data
+	and thereby do not risk losing access by losing an encryption key.
 	
 	\item Finally, create a third encrypted folder.
 	Either you can create this on your computer and upload it to a long-term cloud storage service,

--- a/chapters/data-collection.tex
+++ b/chapters/data-collection.tex
@@ -667,39 +667,6 @@ However, you still need to keep track of your encryption keys as without them yo
 If you remain lucky, you will never have to access your ``master'' or ``golden master'' copies --
 you just want to know it is there, safe, if you need it.
 
-\subsection{Sharing data securely}
-The research team will use the first copy of the raw data
-as the starting point for data cleaning and analysis of the data.
-This raw dataset must remain encrypted at all times if it includes confidential data
- (which is almost always the case).
-As long as the data is properly encrypted,
-it can be shared using insecure modes of communication
-such as email or third-party syncing services.
-While this is safe from a data security perspective,
-this is a burdensome workflow, as anyone accessing the raw data must be listed on the IRB,
-have access to the decryption key and know how to use that key.
-De-identifying the data, or otherwise masking confidential information,
-at the earliest possible opportunity will simplify the workflow without compromising data security.
-Once the data is de-identified, it no longer needs to be encrypted --
-you can share it directly with team members 
-without having to encrypt it and handle decryption keys.
-The next chapter will discuss how to de-identify your data.
-This may not be so straightforward when access to the data
-is restricted by request of the data owner.
-% we should add content about creating / sharing aggregates when individual data is particularly sensitive, e.g. cdr data
-% this is a way to address data owner restrictions and makes this section more applicalbe to non-survey data
-If confidential information is directly required for the analysis itself,
-it will be necessary to keep at least a subset of the data encrypted through the data analysis process.
-
-The data security standards that apply when receiving confidential data also apply when transferring confidential data.
-In some survey software, you can use the same encryption that allows you to receive data securely
-from the field, to also send data to the field.
-But if you are not sure how to do that in the survey software you are using,
-then you should create a secure folder using, for example,
-VeraCrypt, and share that secure folder with the field team.
-Remember that you must always share passwords and keys in a secure way,
-such as through password managers.
-
 Once the raw data is securely stored and backed up, 
 it can be transformed into your final analysis dataset
 through the steps described in the next chapter.

--- a/chapters/data-collection.tex
+++ b/chapters/data-collection.tex
@@ -721,8 +721,7 @@ This is done through a back-up protocol. This is an example of such a protocol:
 
 \noindent This handling satisfies the \textbf{3-2-1 rule}:
 there are two on-site copies of the data and one off-site copy,
-so the data can never be lost in case of hardware failure.\sidenote{
-	\url{https://www.backblaze.com/blog/the-3-2-1-backup-strategy}}
+so the data can never be lost in case of hardware failure.
 %needs wiki page
 However, you still need to keep track of your encryption keys as without them your data is lost.
 If you remain lucky, you will never have to access your ``master'' or ``golden master'' copies --

--- a/chapters/data-collection.tex
+++ b/chapters/data-collection.tex
@@ -553,7 +553,7 @@ Encryption-at-rest requires active participation from the user,
 and you should be fully aware that if your decryption key is lost,
 there is absolutely no way to recover your data.
 
-You should not assume that your data is encrypted at rest by default.
+You should not assume that your data is encrypted-at-rest by default.
 In most data collection platforms,
 encryption-at-rest needs to be explicitly enabled and operated by the user.
 There is no automatic way to implement this,
@@ -564,7 +564,7 @@ Most survey software implement \textbf{asymmetric encryption}\sidenote{
   \url{https://dimewiki.worldbank.org/Encryption\#Asymmetric\_Encryption}}
 where there are two keys in a public/private key pair.
 Only the private key can be used to decrypt the encrypted data,
-and the public key can only be used to encrypt the data.
+when the public key is used to encrypt the data.
 It is therefore safe to send the public key
 to the tablet or the browser used to collect the data.
 

--- a/chapters/data-collection.tex
+++ b/chapters/data-collection.tex
@@ -533,7 +533,7 @@ as long as you are using well established services.
 Encryption-at-rest protects your data when it is stored on a server or your computer.
 Since the storage time is longer than instantaneous,
 you as a user, need to keep track of the key. 
-Anyone with access to the key has access to the sensitive data.
+Anyone with access to the key has access to the confidential data.
 If you do not, the raw data will be accessible by
 individuals who are not approved by your IRB,
 such as tech support personnel,
@@ -668,24 +668,33 @@ Instead, for one-time transfers you can send data over password protected end-to
 
 
 
+\subsection{Backing up original data}
+
+While encryption is protecting your data from unauthorized access,
+you also need to protect your data from being accidentally over-written or deleted.
+This is done through a back-up protocol. This is an example of such a protocol:
 
 \begin{enumerate}
-	\item Create a secure encrypted folder in your project folder.
-  This should be on your computer, and could be in a shared folder.
-  
-	\item Download data from the data collection server to that secure folder.
+	\item Create a encrypted folder in your project folder.
+	This should be on your computer, and could be in a shared folder.
+	
+	\item Download data from the data collection server to that encrypted folder.
 	If you encrypted the data during data collection, you will need \textit{both} the
 	private key used during data collection to be able to download the data,
-	\textit{and} the key used when you created the secure folder to save it there.
+	\textit{and} the key used when you created the encrypted folder to save it there.
 	This your first copy of your raw data, and the copy you will use in your cleaning and analysis.
 	
-	\item Create a secure folder on an external drive that you can keep in a secure location.
-	Copy the data you just downloaded to this second secure	folder.
+	\item Create a second encrypted folder on an external drive that you can keep in a secure location.
+	Copy the data you just downloaded to this second encrypted folder.
 	This is the ``master'' backup copy of the raw data. 
 	You should never work with this data on a day-to-day basis.
-	(Instead of creating a second secure folder, you can simply copy the first secure folder.)
+	You should not use the same encrypted folder or the same key, 
+	because if you use the same key and lose the key, 
+	then you will have lost access to both encrypted folders. 
+	If you have an physical safe where you can securely store the external drive, 
+	then you do not need to encrypt the data and thereby do not risk losing access by losing an encryption key.
 	
-	\item Finally, create a third secure folder.
+	\item Finally, create a third encrypted folder.
 	Either you can create this on your computer and upload it to a long-term cloud storage service,
 	or you can create it on	an external hard drive that you then store in a second location,
 	for example, at another office of your organization.
@@ -693,13 +702,12 @@ Instead, for one-time transfers you can send data over password protected end-to
 	You should never store the ``golden master'' copy in a synced folder, 
 	as it would be deleted in the cloud storage if it is deleted on your computer.
 	You should also never work with this data on a day-to-day basis.
-	(Instead of creating a third secure folder, you can simply copy the first secure folder.)
 \end{enumerate}
 
 \noindent This handling satisfies the \textbf{3-2-1 rule}:
 there are two on-site copies of the data and one off-site copy,
 so the data can never be lost in case of hardware failure.\sidenote{
-  \url{https://www.backblaze.com/blog/the-3-2-1-backup-strategy}}
+	\url{https://www.backblaze.com/blog/the-3-2-1-backup-strategy}}
 %needs wiki page
 However, you still need to keep track of your encryption keys as without them your data is lost.
 If you remain lucky, you will never have to access your ``master'' or ``golden master'' copies --

--- a/chapters/data-collection.tex
+++ b/chapters/data-collection.tex
@@ -583,43 +583,40 @@ and instead the data is stored and processed in a cloud environment.
 There are many available cloud storage solutions
 and you need to understand how the data is encrypted and how the keys are handled.
 This is likely another case where a regular research team will have to ask a cybersecurity expert.
+
+\subsection{Collecting data securely in the field}
+
+All common data collection software will automatically encrypt
+all data in transit (i.e., upload from field or download from server).
+However, it is also necessary to ensure that confidential data 
+are private when stored on a cloud server.
 You should not assume that your data is encrypted-at-rest by default.
 In most data collection platforms,
 encryption-at-rest needs to be explicitly enabled and operated by the user.
-There is no automatic way to implement this,
-because the encryption key may
-never pass through the hands of a third party,
-including the data storage application.
-Most survey software implement \textbf{asymmetric encryption}\sidenote{
-  \url{https://dimewiki.worldbank.org/Encryption\#Asymmetric\_Encryption}}
-where there are two keys in a public/private key pair.
-Only the private key can be used to decrypt the encrypted data,
-when the public key is used to encrypt the data.
-It is therefore safe to send the public key
-to the tablet or the browser used to collect the data.
 
-When you enable asymmetric encryption, the survey software will allow you to create and
-download -- once -- the public/private key pair needed to encrypt and decrypt the data.
-You upload the public key when you start a new survey, 
-and all data encrypted using that public key when collected, 
-can only be accessed with the private key from that specific public/private key pair.
-You must store the key pair in a secure location, 
+When collecting data you want the tablets or the browsers used to collect data
+to be able to encrypt all information before submitting it to the server. 
+At the same time you do not want those devices to have any way of decrypting already submitted data.
+This is a perfect use case for \textbf{asymmetric encryption}
+where there are two keys in a public/private key pair.
+The public key can safely be sent to all tablet or the browser to be used for encrypting the data.
+Only the private key in the same key pair can be used to decrypt that data.
+The private key should be kept secret and not be shared with anyone not listed on the IRB.
+Again, you must store the key pair in a secure location, 
 such as in a secure note in a password manager,
 as there is no way to access your data if the private key is lost.
-Make sure you store your keys with descriptive names to match the survey to which they correspond.
-Any time anyone accesses the data --
-either when viewing it in the browser or downloading it to your computer --
-they will be asked to provide the key.
-Only project team members named in the IRB are allowed access private keys 
-that can be used to decrypt sensitive data.
+
+Data secured this way can securely pass through the server owned by the data collection software provider,
+and you should never decrypt it until it is downloaded on your computer.
+If your data collection service allows you to browse data in the browser, 
+then the encryption is only implemented correctly if you are asked for the key each time.
+
+
 
 \subsection{Storing data securely}
 % doesn't cover 'big' data
 For analysis, you will need to transfer the data from the data collection software to
 a secure location on your computer or a cloud drive.
-While public/private key encryption is optimal for one-way transfer
-from the data collection device to the data collection server,
-it is not practical once you start interacting with the data.
 Instead, at this stage you need \textbf{symmetric encryption}\sidenote{
   \url{https://dimewiki.worldbank.org/Encryption\#Symmetric\_Encryption}}.
 In this set-up, a single key is used to both encrypt and decrypt the information.


### PR DESCRIPTION
This PR includes a re-write of the _Handling Data Securely_ section. I only had two small tasks, and they both related to how to include non-survey data sources to this section. 

Before this re-write the section completely followed the use case of survey data. I tried and tried to add other sources with only small edits,, but I couldn't, and the re-write in this PR is the result of that.

Apart from breaking up the heavy focus on survey data I also wanted move all parts that explained encrytpion to an encryption sub-section. It was weird that, for example, encryption-at-rest, was explained in the data collection sub-section when that is just as relevant in the data storage or data sharing section.

I feel that this version needs some polishing, but I wont be able to make more progress until I at least get some feedback.